### PR TITLE
fix bug : RuntimeError: view size is not compatible with input tensor…

### DIFF
--- a/saliency_maps/scripts/iba.py
+++ b/saliency_maps/scripts/iba.py
@@ -128,7 +128,7 @@ class InformationBottleneck(nn.Module):
 
 
 class IBAInterpreter:
-    def __init__(self, model, estim: Estimator, beta, steps=10, lr=1, batch_size=10, ensemble=False, progbar=False):
+    def __init__(self, model, estim: Estimator, beta, steps=10, lr=1, batch_size=1, ensemble=False, progbar=False):
         self.device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
         self.model = model.to(self.device)
         self.original_layer = estim.get_layer()


### PR DESCRIPTION
When using the MPS backend with default batch_size=10, a RuntimeError may occur: "view size is not compatible...". This stems from MPS's strict memory continuity requirements. Replace tensor.view() with tensor.reshape() to enforce memory reallocation while preserving mathematical equivalence.

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[9], line 5
      3 image_path = "MedCLIP-SAMv2/assets/example.png" # @param {type:"string"}
      4 text = "A medical brain MRI scan showing a well-circumscribed, extra-axial mass suggestive of a meningioma tumor." # @param {type:"string"}
----> 5 vmap = plot(model, image_path, text)

Cell In[8], line 10
      8 # Train information bottleneck on image
      9 print("Training M2IB on the image...")
---> 10 vmap = vision_heatmap_iba(text_ids, image_feat, model, vlayer, vbeta, vvar)
     11 # Train information bottleneck on text
     12 print("Training M2IB on the text...")

File ~/MedCLIP-SAMv2/saliency_maps/scripts/methods.py:58, in vision_heatmap_iba(text_t, image_t, model, layer_idx, beta, var, lr, train_steps, ensemble, progbar)
     56 compression_estimator = get_compression_estimator(var, layer, features)
     57 reader = IBAInterpreter(model, compression_estimator, beta=beta, lr=lr, steps=train_steps, progbar=progbar,ensemble=ensemble)
---> 58 return reader.vision_heatmap(text_t, image_t)

File ~/MedCLIP-SAMv2/saliency_maps/scripts/iba.py:175, in IBAInterpreter.vision_heatmap(self, text_t, image_t)
    174 def vision_heatmap(self, text_t, image_t):
--> 175     saliency, loss_c, loss_f, loss_t = self._run_vision_training(text_t, image_t)
    176     saliency = torch.nansum(saliency, -1)[1:] # Discard the first because it's the CLS token
    177     dim = int(saliency.numel() ** 0.5)

File ~/MedCLIP-SAMv2/saliency_maps/scripts/iba.py:191, in IBAInterpreter._run_vision_training(self, text_t, image_t)
    189 def _run_vision_training(self, text_t, image_t):
    190     replace_layer(self.model.vision_model, self.original_layer, self.sequential)
--> 191     loss_c, loss_f, loss_t = self._train_bottleneck(text_t, image_t)
    192     replace_layer(self.model.vision_model, self.sequential, self.original_layer)
    193     return self.bottleneck.buffer_capacity.mean(axis=0), loss_c, loss_f, loss_t

File ~/MedCLIP-SAMv2/saliency_maps/scripts/iba.py:209, in IBAInterpreter._train_bottleneck(self, text_t, image_t)
    207         out = self.model.get_text_features(batch[0]), self.model.get_image_features(batch[1])
    208         loss_c, loss_f, loss_t = self.calc_loss(outputs=out[0], labels=out[1])
--> 209         loss_t.backward()
    210         optimizer.step(closure=None)
    212 else:

File ~/.conda/envs/medclip_samv2/lib/python3.11/site-packages/torch/_tensor.py:581, in Tensor.backward(self, gradient, retain_graph, create_graph, inputs)
    571 if has_torch_function_unary(self):
    572     return handle_torch_function(
    573         Tensor.backward,
    574         (self,),
   (...)
    579         inputs=inputs,
    580     )
--> 581 torch.autograd.backward(
    582     self, gradient, retain_graph, create_graph, inputs=inputs
    583 )

File ~/.conda/envs/medclip_samv2/lib/python3.11/site-packages/torch/autograd/__init__.py:347, in backward(tensors, grad_tensors, retain_graph, create_graph, grad_variables, inputs)
    342     retain_graph = create_graph
    344 # The reason we repeat the same comment below is that
    345 # some Python versions print out the first line of a multi-line function
    346 # calls in the traceback and some print out the last line
--> 347 _engine_run_backward(
    348     tensors,
    349     grad_tensors_,
    350     retain_graph,
    351     create_graph,
    352     inputs,
    353     allow_unreachable=True,
    354     accumulate_grad=True,
    355 )

File ~/.conda/envs/medclip_samv2/lib/python3.11/site-packages/torch/autograd/graph.py:825, in _engine_run_backward(t_outputs, *args, **kwargs)
    823     unregister_hooks = _register_logging_hooks_on_whole_graph(t_outputs)
    824 try:
--> 825     return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
    826         t_outputs, *args, **kwargs
    827     )  # Calls into the C++ engine to run the backward pass
    828 finally:
    829     if attach_logging_hooks:

RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.